### PR TITLE
Update gif-list.svelte

### DIFF
--- a/src/routes/home/ui/gif-list.svelte
+++ b/src/routes/home/ui/gif-list.svelte
@@ -2,6 +2,8 @@
 	import type { Gif } from '$lib/interfaces';
 	import { Browser } from '@capacitor/browser';
 	import { createEventDispatcher } from 'svelte';
+	
+	import { chatbubbles } from 'ionicons/icons';
 
 	export let gifs: Gif[] | undefined;
 
@@ -79,7 +81,7 @@
 					<ion-label> {gif.title} </ion-label>
 					<!-- svelte-ignore a11y-click-events-have-key-events -->
 					<ion-button data-test="gif-comments-button" on:click={() => showComments(gif)}>
-						<ion-icon name="chatbubbles" />
+						<ion-icon icon={chatbubbles} />
 						{gif.comments}
 					</ion-button>
 				</ion-list-header>


### PR DESCRIPTION
Icon syntax - cannot use the label syntax like in Angular. Gives error. Needs Vue like imports

```
Uncaught TypeError: Failed to construct 'URL': Invalid base URL
    at getAssetPath (index.js:33:22)
    at getNamedUrl (icon.js:46:10)
    at getUrl (icon.js:27:12)
    at proxyCustomElement.mode.loadIcon (icon.js:276:19)
    at icon.js:241:12
    at proxyCustomElement.mode.waitUntilVisible (icon.js:264:7)
    at proxyCustomElement.mode.connectedCallback (icon.js:239:10)
    at proxyCustomElement.mode.connectedCallback (index.js:2420:43)
    at append_hydration (index.mjs:359:16)
    at append_hydration_dev (index.mjs:2124:5)
```